### PR TITLE
#22 Implement PersistentTokenService, token invalidation

### DIFF
--- a/src/main/java/io/github/javacoded78/jwthumble/service/PersistentTokenService.java
+++ b/src/main/java/io/github/javacoded78/jwthumble/service/PersistentTokenService.java
@@ -1,0 +1,27 @@
+package io.github.javacoded78.jwthumble.service;
+
+import io.github.javacoded78.jwthumble.config.TokenParameters;
+
+/**
+ * Interface if PersistentTokenService.
+ */
+public interface PersistentTokenService extends TokenService {
+
+    /**
+     * Removes JWT token from storage. Method removes all entries
+     * of the same token.
+     *
+     * @param token JWT token to be removed
+     * @return true - if JWT token was removed, false - otherwise
+     */
+    boolean invalidate(String token);
+
+    /**
+     * Removes JWT token from storage.
+     *
+     * @param params params of JWT token
+     * @return true - if JWT token was removed, false - otherwise
+     */
+    boolean invalidate(TokenParameters params);
+
+}

--- a/src/main/java/io/github/javacoded78/jwthumble/service/PersistentTokenServiceImpl.java
+++ b/src/main/java/io/github/javacoded78/jwthumble/service/PersistentTokenServiceImpl.java
@@ -17,7 +17,7 @@ import java.util.Map;
 /**
  * Implementation of TokenService with JWT token storage.
  */
-public class PersistentTokenServiceImpl implements TokenService {
+public class PersistentTokenServiceImpl implements PersistentTokenService {
 
     /**
      * Secret key for verifying JWT token.
@@ -146,6 +146,16 @@ public class PersistentTokenServiceImpl implements TokenService {
                 .build()
                 .parseSignedClaims(token);
         return new HashMap<>(claims.getPayload());
+    }
+
+    @Override
+    public boolean invalidate(final String token) {
+        return tokenStorage.remove(token);
+    }
+
+    @Override
+    public boolean invalidate(final TokenParameters params) {
+        return tokenStorage.remove(params);
     }
 
 }

--- a/src/main/java/io/github/javacoded78/jwthumble/storage/RedisTokenStorageImpl.java
+++ b/src/main/java/io/github/javacoded78/jwthumble/storage/RedisTokenStorageImpl.java
@@ -122,4 +122,35 @@ public class RedisTokenStorageImpl implements TokenStorage {
         }
     }
 
+    @Override
+    public boolean remove(final String token) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            String script = """
+                    local keys = redis.call('keys', ARGV[1])
+                    for _, key in ipairs(keys) do
+                      redis.call('del', key)
+                    end
+                    return #keys > 0
+                    """;
+            Long result = (Long) jedis.eval(
+                    script,
+                    0,
+                    "*",
+                    token
+            );
+            return result != null && result > 0;
+        }
+    }
+
+    @Override
+    public boolean remove(final TokenParameters params) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            String tokenKey = redisSchema.subjectTokenKey(
+                    params.getSubject(),
+                    params.getType()
+            );
+            return jedis.del(tokenKey) > 0;
+        }
+    }
+
 }

--- a/src/main/java/io/github/javacoded78/jwthumble/storage/TokenStorage.java
+++ b/src/main/java/io/github/javacoded78/jwthumble/storage/TokenStorage.java
@@ -34,4 +34,20 @@ public interface TokenStorage {
      */
     String get(TokenParameters params);
 
+    /**
+     * Removes JWT token from storage.
+     *
+     * @param token JWT token to be removed
+     * @return true - if JWT token was removed, false - otherwise
+     */
+    boolean remove(String token);
+
+    /**
+     * Removes JWT token from storage.
+     *
+     * @param params params of JWT token
+     * @return true - if JWT token was removed, false - otherwise
+     */
+    boolean remove(TokenParameters params);
+
 }

--- a/src/main/java/io/github/javacoded78/jwthumble/storage/TokenStorageImpl.java
+++ b/src/main/java/io/github/javacoded78/jwthumble/storage/TokenStorageImpl.java
@@ -4,6 +4,7 @@ import io.github.javacoded78.jwthumble.config.TokenParameters;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Basic implementation of TokenStorage. Not thread-safe.
@@ -54,6 +55,28 @@ public class TokenStorageImpl implements TokenStorage {
                 params.getType()
         );
         return tokens.get(tokenKey);
+    }
+
+    @Override
+    public boolean remove(final String token) {
+        AtomicBoolean deleted = new AtomicBoolean(false);
+        for (Map.Entry<String, String> entry : tokens.entrySet()) {
+            if (entry.getValue().equals(token)) {
+                tokens.remove(entry.getKey());
+                deleted.set(true);
+                return true;
+            }
+        }
+        return deleted.get();
+    }
+
+    @Override
+    public boolean remove(final TokenParameters params) {
+        String tokenKey = subjectTokenKey(
+                params.getSubject(),
+                params.getType()
+        );
+        return tokens.remove(tokenKey) != null;
     }
 
 }

--- a/src/test/java/io/github/javacoded78/jwthumble/fake/FakeTokenStorageImpl.java
+++ b/src/test/java/io/github/javacoded78/jwthumble/fake/FakeTokenStorageImpl.java
@@ -4,6 +4,7 @@ import io.github.javacoded78.jwthumble.config.TokenParameters;
 import io.github.javacoded78.jwthumble.storage.TokenStorage;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class FakeTokenStorageImpl implements TokenStorage {
 
@@ -41,6 +42,28 @@ public class FakeTokenStorageImpl implements TokenStorage {
                 params.getType()
         );
         return token.equals(tokens.get(tokenKey));
+    }
+
+    @Override
+    public boolean remove(final String token) {
+        AtomicBoolean deleted = new AtomicBoolean(false);
+        for (Map.Entry<String, String> entry : tokens.entrySet()) {
+            if (entry.getValue().equals(token)) {
+                tokens.remove(entry.getKey());
+                deleted.set(true);
+                return true;
+            }
+        }
+        return deleted.get();
+    }
+
+    @Override
+    public boolean remove(final TokenParameters params) {
+        String tokenKey = subjectTokenKey(
+                params.getSubject(),
+                params.getType()
+        );
+        return tokens.remove(tokenKey) != null;
     }
 
 }

--- a/src/test/java/io/github/javacoded78/jwthumble/service/PersistentTokenServiceImplTests.java
+++ b/src/test/java/io/github/javacoded78/jwthumble/service/PersistentTokenServiceImplTests.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -165,6 +166,60 @@ class PersistentTokenServiceImplTests {
         System.out.println(claims.get("key1"));
         assertEquals("value1", claims.get("key1"));
         assertEquals(123, claims.get("key2"));
+    }
+
+    @Test
+    void invalidate_Token() {
+        TokenParameters params = TokenParameters.builder(
+                        subject,
+                        type,
+                        duration
+                )
+                .build();
+        String token = tokenService.create(params);
+
+        tokenService.invalidate(token);
+
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException ignored) {
+        }
+
+        TokenParameters newParams = TokenParameters.builder(
+                        subject,
+                        type,
+                        duration
+                )
+                .build();
+        String newToken = tokenService.create(newParams);
+        assertNotEquals(token, newToken);
+    }
+
+    @Test
+    void invalidate_SubjectAndType() {
+        TokenParameters params = TokenParameters.builder(
+                        subject,
+                        type,
+                        duration
+                )
+                .build();
+        String token = tokenService.create(params);
+
+        tokenService.invalidate(params);
+
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException ignored) {
+        }
+
+        TokenParameters newParams = TokenParameters.builder(
+                        subject,
+                        type,
+                        duration
+                )
+                .build();
+        String newToken = tokenService.create(newParams);
+        assertNotEquals(token, newToken);
     }
 
 }

--- a/src/test/java/io/github/javacoded78/jwthumble/storage/RedisTokenStorageImplTests.java
+++ b/src/test/java/io/github/javacoded78/jwthumble/storage/RedisTokenStorageImplTests.java
@@ -127,4 +127,44 @@ class RedisTokenStorageImplTests {
         assertNull(tokenStorage.get(params));
     }
 
+    @Test
+    void invalidate_Token() {
+        TokenParameters params = TokenParameters.builder(
+                        subject,
+                        type,
+                        duration
+                )
+                .build();
+        String token = "testToken";
+        tokenStorage.save(
+                token,
+                params
+        );
+
+        tokenStorage.remove(token);
+
+        String existingToken = tokenStorage.get(params);
+        assertNull(existingToken);
+    }
+
+    @Test
+    void invalidate_SubjectAndType() {
+        TokenParameters params = TokenParameters.builder(
+                        subject,
+                        type,
+                        duration
+                )
+                .build();
+        String token = "testToken";
+        tokenStorage.save(
+                token,
+                params
+        );
+
+        tokenStorage.remove(params);
+
+        String existingToken = tokenStorage.get(params);
+        assertNull(existingToken);
+    }
+
 }

--- a/src/test/java/io/github/javacoded78/jwthumble/storage/TokenStorageImplTests.java
+++ b/src/test/java/io/github/javacoded78/jwthumble/storage/TokenStorageImplTests.java
@@ -101,5 +101,45 @@ class TokenStorageImplTests {
 
         assertNull(tokenStorage.get(params));
     }
+
+    @Test
+    void invalidate_Token() {
+        TokenParameters params = TokenParameters.builder(
+                        subject,
+                        type,
+                        duration
+                )
+                .build();
+        String token = "testToken";
+        tokenStorage.save(
+                token,
+                params
+        );
+
+        tokenStorage.remove(token);
+
+        String existingToken = tokenStorage.get(params);
+        assertNull(existingToken);
+    }
+
+    @Test
+    void invalidate_SubjectAndType() {
+        TokenParameters params = TokenParameters.builder(
+                        subject,
+                        type,
+                        duration
+                )
+                .build();
+        String token = "testToken";
+        tokenStorage.save(
+                token,
+                params
+        );
+
+        tokenStorage.remove(params);
+
+        String existingToken = tokenStorage.get(params);
+        assertNull(existingToken);
+    }
 }
 


### PR DESCRIPTION
close #22 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances token invalidation in `PersistentTokenService` by adding methods to remove tokens by token or parameters. 

### Detailed summary
- Added `invalidate` methods in `PersistentTokenService` to remove tokens by token or parameters
- Implemented `remove` methods in `RedisTokenStorageImpl` and `TokenStorageImpl`
- Updated tests for token invalidation in various scenarios

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->