### PR TITLE
#27 Implement getting claim by its name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.rultor.yml
+++ b/.rultor.yml
@@ -1,3 +1,5 @@
+architect:
+  - javacoded78
 assets:
   settings.xml: javacoded78/secrets#assets/settings.xml
   secring.gpg: javacoded78/secrets#assets/Andrei Soroka_0x872A42FB_SECRET.gpg

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This repository is an open-source Java library for fast and convenient using of 
     * [Get subject from token](#get-subject-from-jwt-token)
     * [Get type from token](#get-type-from-jwt-token)
     * [Get claims from token](#get-claims-from-jwt-token)
+    * [Get claim from token](#get-claim-from-jwt-token)
 * [How to contribute](#how-to-contribute)
 
 ## How to use
@@ -239,6 +240,21 @@ public class Main {
         String token="eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhbmRyb3Nvcjk5QGdtYWlsLmNvbSIsImlkIjozLCJyb2xlcyI6WyJST0xFX1VTRVIiXSwiZXhwIjoxNzE3MTQ1MDIxfQ.w8ZFLFsKf7Qs9_dNb0WzdoyAIpWtfeEyqLfNI_G16_6NHbGwCRbeVVm_a_DzckytsyGYHTWRlZdi_gWK-HjrXg";
         Map<String, Object> claims=tokenService.claims(token);
         claims.forEach((key,value)->System.out.println(key + " " + value));
+    }
+}
+
+```
+
+### Get claim from JWT token
+
+To get claim by its name from JWT token payload call method `claim(String token, String key)`on `TokenService` object.
+
+```java
+public class Main {
+    public static void main(String[] args) {
+        String token="eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhbmRyb3Nvcjk5QGdtYWlsLmNvbSIsImlkIjozLCJyb2xlcyI6WyJST0xFX1VTRVIiXSwiZXhwIjoxNzE3MTQ1MDIxfQ.w8ZFLFsKf7Qs9_dNb0WzdoyAIpWtfeEyqLfNI_G16_6NHbGwCRbeVVm_a_DzckytsyGYHTWRlZdi_gWK-HjrXg";
+        String claim = (String) tokenService.claim(token, "subject");
+        System.out.println(claim);
     }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <jjwt.version>0.12.5</jjwt.version>
         <lombok.version>1.18.32</lombok.version>
         <jedis.version>5.1.3</jedis.version>
-        <checkstyle.version>3.2.2</checkstyle.version>
+        <checkstyle.version>3.3.1</checkstyle.version>
         <junit-version>5.10.2</junit-version>
         <testcontainers.version>1.19.8</testcontainers.version>
         <jacoco.version>0.8.11</jacoco.version>

--- a/src/main/java/io/github/javacoded78/jwthumble/service/PersistentTokenServiceImpl.java
+++ b/src/main/java/io/github/javacoded78/jwthumble/service/PersistentTokenServiceImpl.java
@@ -149,6 +149,18 @@ public class PersistentTokenServiceImpl implements PersistentTokenService {
     }
 
     @Override
+    public Object claim(final String token,
+                        final String key) {
+        Jws<Claims> claims = Jwts
+                .parser()
+                .verifyWith(this.key)
+                .build()
+                .parseSignedClaims(token);
+        return claims.getPayload()
+                .get(key);
+    }
+
+    @Override
     public boolean invalidate(final String token) {
         return tokenStorage.remove(token);
     }

--- a/src/main/java/io/github/javacoded78/jwthumble/service/TokenService.java
+++ b/src/main/java/io/github/javacoded78/jwthumble/service/TokenService.java
@@ -73,4 +73,14 @@ public interface TokenService {
      */
     Map<String, Object> claims(String token);
 
+    /**
+     * Returns claim of JWT token by its key.
+     *
+     * @param token JWT token
+     * @param key   key of claim
+     * @return value of claim or null if there is no value
+     */
+    Object claim(String token,
+                 String key);
+
 }

--- a/src/main/java/io/github/javacoded78/jwthumble/service/TokenServiceImpl.java
+++ b/src/main/java/io/github/javacoded78/jwthumble/service/TokenServiceImpl.java
@@ -122,4 +122,16 @@ public class TokenServiceImpl implements TokenService {
         return new HashMap<>(claims.getPayload());
     }
 
+    @Override
+    public Object claim(final String token,
+                        final String key) {
+        Jws<Claims> claims = Jwts
+                .parser()
+                .verifyWith(this.key)
+                .build()
+                .parseSignedClaims(token);
+        return claims.getPayload()
+                .get(key);
+    }
+
 }

--- a/src/test/java/io/github/javacoded78/jwthumble/service/PersistentTokenServiceImplTests.java
+++ b/src/test/java/io/github/javacoded78/jwthumble/service/PersistentTokenServiceImplTests.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PersistentTokenServiceImplTests {
@@ -166,6 +167,51 @@ class PersistentTokenServiceImplTests {
         System.out.println(claims.get("key1"));
         assertEquals("value1", claims.get("key1"));
         assertEquals(123, claims.get("key2"));
+    }
+
+    @Test
+    void claim_ExistingKey_ReturnsCorrectClaimValue() {
+        Map<String, Object> customClaims = new HashMap<>();
+        customClaims.put("key1", "value1");
+        customClaims.put("key2", 123);
+
+        TokenParameters params = TokenParameters.builder(
+                        subject,
+                        type,
+                        duration
+                )
+                .claims(customClaims)
+                .build();
+
+        String token = tokenService.create(params);
+        Object claim = tokenService.claim(
+                token,
+                "key1"
+        );
+        assertNotNull(claim);
+        assertEquals("value1", claim);
+    }
+
+    @Test
+    void claim_NotExistingKey_ReturnsNull() {
+        Map<String, Object> customClaims = new HashMap<>();
+        customClaims.put("key1", "value1");
+        customClaims.put("key2", 123);
+
+        TokenParameters params = TokenParameters.builder(
+                        subject,
+                        type,
+                        duration
+                )
+                .claims(customClaims)
+                .build();
+
+        String token = tokenService.create(params);
+        Object claim = tokenService.claim(
+                token,
+                "notExistingKey"
+        );
+        assertNull(claim);
     }
 
     @Test

--- a/src/test/java/io/github/javacoded78/jwthumble/service/TokenServiceImplTest.java
+++ b/src/test/java/io/github/javacoded78/jwthumble/service/TokenServiceImplTest.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TokenServiceImplTest {
@@ -152,6 +153,51 @@ class TokenServiceImplTest {
         assertNotNull(claims);
         assertEquals("value1", claims.get("key1"));
         assertEquals(123, claims.get("key2"));
+    }
+
+    @Test
+    void claim_ExistingKey_ReturnsCorrectClaimValue() {
+        Map<String, Object> customClaims = new HashMap<>();
+        customClaims.put("key1", "value1");
+        customClaims.put("key2", 123);
+
+        TokenParameters params = TokenParameters.builder(
+                        subject,
+                        type,
+                        duration
+                )
+                .claims(customClaims)
+                .build();
+
+        String token = tokenService.create(params);
+        Object claim = tokenService.claim(
+                token,
+                "key1"
+        );
+        assertNotNull(claim);
+        assertEquals("value1", claim);
+    }
+
+    @Test
+    void claim_NotExistingKey_ReturnsNull() {
+        Map<String, Object> customClaims = new HashMap<>();
+        customClaims.put("key1", "value1");
+        customClaims.put("key2", 123);
+
+        TokenParameters params = TokenParameters.builder(
+                        subject,
+                        type,
+                        duration
+                )
+                .claims(customClaims)
+                .build();
+
+        String token = tokenService.create(params);
+        Object claim = tokenService.claim(
+                token,
+                "notExistingKey"
+        );
+        assertNull(claim);
     }
 
 }

--- a/src/test/java/io/github/javacoded78/jwthumble/storage/TokenStorageImplTests.java
+++ b/src/test/java/io/github/javacoded78/jwthumble/storage/TokenStorageImplTests.java
@@ -141,5 +141,6 @@ class TokenStorageImplTests {
         String existingToken = tokenStorage.get(params);
         assertNull(existingToken);
     }
+
 }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates dependencies, adds a new method to retrieve a specific claim from a JWT token, and includes test cases for the new method.

### Detailed summary
- Updated dependencies in `pom.xml`
- Added `claim` method to `TokenService` interface and implementations
- Added tests for the `claim` method in `TokenServiceImpl` and `PersistentTokenServiceImpl`
- Updated README with information on how to use the new `claim` method

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->